### PR TITLE
Fixed issue that prevented the private key being included

### DIFF
--- a/idtranslationsample/modules/IdentityTranslationModule/Connection/CompositeDeviceClient.cs
+++ b/idtranslationsample/modules/IdentityTranslationModule/Connection/CompositeDeviceClient.cs
@@ -176,6 +176,8 @@ namespace IdentityTranslationModule.Connection
                             throw new Exception("Failed to detect private key algorithm");
                     }
 
+                    // Export the certificate in PFX format to ensure the private key is included
+                    clientCertPrivateKeyPair = new X509Certificate2(clientCertPrivateKeyPair.Export(X509ContentType.Pfx));
                     certificates.Add(clientCertPrivateKeyPair);
                 }
                 else
@@ -211,10 +213,10 @@ namespace IdentityTranslationModule.Connection
                     IgnoreCertificateChainErrors = false,
                     IgnoreCertificateRevocationErrors = true,
                     CertificateValidationHandler = (MqttClientCertificateValidationCallbackContext c) =>
-                                    {
-                                        Console.WriteLine("Certificate--> issuer: " + c.Certificate.Issuer + " subject: " + c.Certificate.Subject);
-                                        return true;
-                                    }                      
+                    {
+                        Console.WriteLine("Certificate--> issuer: " + c.Certificate.Issuer + " subject: " + c.Certificate.Subject);
+                        return true;
+                    }                      
                 });
             }
             


### PR DESCRIPTION
The the X509 Certificate for the client is presented in the connection it needs to be in PFX format, either the originally imported file is a PFX containing the key or the key is loaded and added public certificate it must be exported as PFX so that the key is presented with the certificate.